### PR TITLE
common-apps: Add configure options to fix empty libgcov.a

### DIFF
--- a/common-apps-functions-source.sh
+++ b/common-apps-functions-source.sh
@@ -2264,6 +2264,8 @@ function build_cross_gcc_first()
           config_options+=("--with-newlib") # Arm, AArch64
 
           config_options+=("--with-system-zlib")
+          config_options+=("--with-sysroot=${APP_PREFIX}/${GCC_TARGET}")
+          config_options+=("--with-native-system-header-dir=/include")
 
           if [ "${GCC_TARGET}" == "arm-none-eabi" ]
           then
@@ -2844,6 +2846,8 @@ function build_cross_gcc_final()
           config_options+=("--with-pkgversion=${BRANDING}")
 
           config_options+=("--with-system-zlib")
+          config_options+=("--with-sysroot=${APP_PREFIX}/${GCC_TARGET}")
+          config_options+=("--with-native-system-header-dir=/include")
 
           if [ "${GCC_TARGET}" == "arm-none-eabi" ]
           then


### PR DESCRIPTION
In latest release of arm-none-eabi-gcc-xpack `libgcov.a` has empty functions. 

Adding `--with-sysroot` and `--with-native-system-header-dir` options to configure fixes that issue.