### PR TITLE
Add test for unchecked exception handler

### DIFF
--- a/tests/c-cpp/unchecked-exception.cpp
+++ b/tests/c-cpp/unchecked-exception.cpp
@@ -1,0 +1,7 @@
+// repro for clangd crash from github.com/clangd/clangd issue #1072
+#include <exception>
+int main() {
+    std::exception_ptr foo;
+    try {} catch (...) { }
+    return 0;
+}


### PR DESCRIPTION
Tests a segfault bug in clangd<15, see github issue clangd/clangd #1072

used by xpack-dev-tools/clang-xpack